### PR TITLE
build: [DEV-4040] Add dependabot for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # Enable version updates for GitHub actions.
+  - package-ecosystem: "github-actions"
+    # Set the directory to "/" to check for workflow files in .github/workflows.
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "build(dep)"


### PR DESCRIPTION
## Motivation
- Add dependabot for updating github action versions.

*JIRA*: https://springlabs.atlassian.net/browse/DEV-4040

## Implementation
Dependabot will run daily to update GitHub actions when new versions are released.

Read more about GitHub dependabot here: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

## Checklist
- [x] PR title format follows the guide in the `.github/CONTRIBUTING.md`
